### PR TITLE
This fixes issue of extremely long word generation

### DIFF
--- a/main/main.pde
+++ b/main/main.pde
@@ -22,15 +22,15 @@ static final StringList diphs = new StringList(
 
 // Consonant shifts loosely based on Grimm's law
 static final StringList shift1 = new StringList(
-  "bh", "b", "p", "pf"
+  "h", "b", "p", "f"
 );
 
 static final StringList shift2 = new StringList(
-  "dh", "d", "t", "th"
+  "w", "d", "t", "h"
 );
 
 static final StringList shift3 = new StringList(
-  "gh", "g", "k", "x"
+  "h", "g", "k", "x"
 );
 
 static final StringList shift4 = new StringList(
@@ -38,7 +38,7 @@ static final StringList shift4 = new StringList(
 );
 
 static final StringList shift5 = new StringList(
-  "th", "pf", "w", "h"
+  "th", "pf", "wt", "hkp"
 );
 
 void setup() {


### PR DESCRIPTION
The reason for longer word generation after several generations is caused by your shifts.

For example the shift below.
Starting with the word "bhabtp"

```java
static final StringList shift1 = new StringList(
  "bh", "b", "p", "pf"
);
```

After one pass through mutation the shift changes all instances of "b" to "bh"
Now the word is "bhhabhtp"
After another pass through mutation the shift changes all instances of "p" to "pf"
Now the word is "bhhabhtppf"

With only two(random) passes through the ```consantMutation()``` method, a 6 letter word has now become a 10 letter word.  You can see how after 10 or 20 passes through the ```constantMutaion()``` method a word can become very large.

There are two possible solutions to this problem.
1. Make sure all shift strings are the same length.  This will prevent the lengthening of words during mutation.

2. Make the shift strings longer in length to make it less likely they will appear in a word, this will reduce the likelihood of a word becoming very large, although it might sill be possible.

3. Remove duplicate letters if the word becomes too large.  This may indirectly effect the ```doubleConsonant()``` method.

The commit I provided contains parts of solutions 1 and 2 listed above.
Shift 1, 2 and 3 use the first solution.
Shift 4, 5 use the second solution.

I ran the simulation for several minutes without the mutation of words longer than 10 - 15 characters.

closes #7 